### PR TITLE
Reader::ReadEvent return non const pointer

### DIFF
--- a/reader/Reader.cxx
+++ b/reader/Reader.cxx
@@ -69,7 +69,7 @@ void Reader::ProcessFile(UInt_t nEvents)
 	}
 }
 
-const DetEventFull* Reader::ReadEvent(Int_t iEvent)
+DetEventFull* Reader::ReadEvent(Int_t iEvent)
 {
 	if (iEvent < 0 || iEvent >= GetNEventsTotal()) {
 		cerr << "The event number is greater than total events number in input file!";

--- a/reader/Reader.h
+++ b/reader/Reader.h
@@ -23,7 +23,7 @@ public:
 
 	void ProcessFile(UInt_t nEvents = 10);
 
-	const DetEventFull* ReadEvent(Int_t iEvent);
+	DetEventFull* ReadEvent(Int_t iEvent);
 
 	Long64_t GetNEventsTotal() const;
 private: // data members


### PR DESCRIPTION
Что-то я переборщил с безопасностью. У const TGo4EventElement не работает GetChild, так как он не const.